### PR TITLE
Always require a precision when  instantiating from bigint

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -12,7 +12,8 @@ Represents a type that can be converted to a `BigUnit` if a precision value is a
 
 Arithmetic operations return another BigUnit instance with the precision of the highest of the two numbers. To change to another precision, append `asPrecision(myPrecision)`. 
 If the parameter passed into an arithmetic function is not an instance of `BigUnit`, it will be converted to a `BigUnit` via `BigUnit.from()`. For example, assuming `myUnit` is a `BigUnit` instance with a precision of 5,
-`myUnit.add(2)` will add `2` units to myBigUnit. `myBigUnit.add(BigUnit.from(2n))` will add `0.00002` units to myBigUnit.
+`myUnit.add(2)` will add `2` units to myBigUnit. `myBigUnit.add(BigUnit.from(2n))` will add `0.00002` units to myBigUnit. The exception to this is when the parameter is a `bigint`. In this case, the precision must be passed as a parameter.
+This improves clarity and prevents errors when working with different precisions.
 
 ### constructor(value: bigint, precision: number, name?: string)`
 Constructs a new instance of `BigUnit` from a `bigint`. BigUnit instances can also be instantiated with the static factory methods `from`, `fromBigInt`, `fromNumber`, `fromDecimalString`, `fromValueString`, and `fromObject`.

--- a/src/bigunit.ts
+++ b/src/bigunit.ts
@@ -37,6 +37,15 @@ export class BigUnit {
     }
   }
 
+  public makeOther(other: BigUnitish, otherPrecision?: number): BigUnit {
+    if (typeof other === "bigint" && otherPrecision === undefined) {
+      throw new MissingPrecisionError();
+    }
+    const otherUnit =
+      other instanceof BigUnit ? other : BigUnit.from(other, otherPrecision ?? this.precision);
+    return otherUnit;
+  }
+
   /**
    * @description Add the other value to this value
    * @param other
@@ -44,8 +53,7 @@ export class BigUnit {
    */
   public add(other: BigUnitish): BigUnit {
     // Ensure the other value is a BigUnit
-    const otherUnit =
-      other instanceof BigUnit ? other : BigUnit.from(other, this.precision);
+    const otherUnit = this.makeOther(other);
 
     // Determine the highest precision of the two units and convert both units to the highest precision
     const [thisUnitAtHighestPrecision, otherUnitAtHighestPrecision] =
@@ -63,11 +71,10 @@ export class BigUnit {
    * @param other
    * @returns new BigUnit with the result value in the highest precision
    */
-  public sub(other: BigUnitish): BigUnit {
+  public sub(other: BigUnitish, otherPrecision?: number): BigUnit {   
     // Ensure the other value is a BigUnit
-    const otherUnit =
-      other instanceof BigUnit ? other : BigUnit.from(other, this.precision);
-
+    const otherUnit = this.makeOther(other, otherPrecision);
+    
     // Determine the highest precision of the two units and convert both units to the highest precision
     const [thisUnitAtHighestPrecision, otherUnitAtHighestPrecision] =
       BigUnit.asHighestPrecision(this, otherUnit);
@@ -84,10 +91,9 @@ export class BigUnit {
    * @param other
    * @returns new BigUnit with the result value in the highest precision
    */
-  public mul(other: BigUnitish): BigUnit {
+  public mul(other: BigUnitish, otherPrecision?: number): BigUnit {
     // Ensure the other value is a BigUnit
-    const otherUnit =
-      other instanceof BigUnit ? other : BigUnit.from(other, this.precision);
+    const otherUnit = this.makeOther(other, otherPrecision);
 
     // Determine the highest precision of the two units and convert both units to the highest precision
     const [thisUnitAtHighestPrecision, otherUnitAtHighestPrecision] =
@@ -109,8 +115,7 @@ export class BigUnit {
    */
   public div(other: BigUnitish): BigUnit {
     // Ensure the other value is a BigUnit
-    const otherUnit =
-      other instanceof BigUnit ? other : BigUnit.from(other, this.precision);
+    const otherUnit = this.makeOther(other);
 
     // Determine the highest precision of the two units and convert both units to the highest precision
     const [thisUnitAtHighestPrecision, otherUnitAtHighestPrecision] =
@@ -135,8 +140,7 @@ export class BigUnit {
    */
   public mod(other: BigUnitish): BigUnit {
     // Ensure the other value is a BigUnit
-    const otherUnit =
-      other instanceof BigUnit ? other : BigUnit.from(other, this.precision);
+    const otherUnit = this.makeOther(other);
 
     // Determine the highest precision of the two units and convert both units to the highest precision
     const [thisUnitAtHighestPrecision, otherUnitAtHighestPrecision] =
@@ -207,19 +211,24 @@ export class BigUnit {
   }
 
   /**
+   * @description Remove previously added percentage from this value. 
+   * This is sometimes referred to as "backing out" a percentage. 
+   * @param percent
+   * @returns new BigUnit with the result value in the same precision
+   */
+  public percentBackout(percent: number): BigUnit {
+    return this.div(BigUnit.from(1).percent(percent));
+  }
+
+  /**
    * @description Equality check
    * @param other
    * @returns True if the values are equal, false otherwise
    */
-  public eq(other: BigUnitish): boolean {
-    if (other instanceof BigUnit) {
-      const highestPrecision = Math.max(this.precision, other.precision);
-      return (
-        this.asPrecision(highestPrecision).value ===
-        other.asPrecision(highestPrecision).value
-      );
-    }
-    return this.value === BigUnit.from(other, this.precision).value;
+  public eq(other: BigUnitish, otherPrecision?: number): boolean {
+    const otherUnit = this.makeOther(other, otherPrecision); 
+    const [thisUnitAtHighestPrecision, otherUnitAtHighestPrecision] = BigUnit.asHighestPrecision(this, otherUnit);
+    return thisUnitAtHighestPrecision.value === otherUnitAtHighestPrecision.value;
   }
 
   /**
@@ -227,15 +236,11 @@ export class BigUnit {
    * @param other
    * @returns True if the other value is greater than this value, false otherwise
    */
-  public gt(other: BigUnitish): boolean {
-    if (other instanceof BigUnit) {
-      const highestPrecision = Math.max(this.precision, other.precision);
-      return (
-        this.asPrecision(highestPrecision).value >
-        other.asPrecision(highestPrecision).value
-      );
-    }
-    return this.value > BigUnit.from(other, this.precision).value;
+  public gt(other: BigUnitish, otherPrecision?: number): boolean {
+    const otherUnit = this.makeOther(other, otherPrecision); 
+    const [thisUnitAtHighestPrecision, otherUnitAtHighestPrecision] = BigUnit.asHighestPrecision(this, otherUnit);
+ 
+    return thisUnitAtHighestPrecision.value > otherUnitAtHighestPrecision.value;
   }
 
   /**
@@ -243,15 +248,11 @@ export class BigUnit {
    * @param other
    * @returns True if the other value is less than this value, false otherwise
    */
-  public lt(other: BigUnitish): boolean {
-    if (other instanceof BigUnit) {
-      const highestPrecision = Math.max(this.precision, other.precision);
-      return (
-        this.asPrecision(highestPrecision).value <
-        other.asPrecision(highestPrecision).value
-      );
-    }
-    return this.value < BigUnit.from(other, this.precision).value;
+  public lt(other: BigUnitish, otherPrecision?: number): boolean {
+    const otherUnit = this.makeOther(other, otherPrecision); 
+    const [thisUnitAtHighestPrecision, otherUnitAtHighestPrecision] = BigUnit.asHighestPrecision(this, otherUnit);
+ 
+    return thisUnitAtHighestPrecision.value < otherUnitAtHighestPrecision.value;
   }
 
   /**
@@ -259,15 +260,11 @@ export class BigUnit {
    * @param other
    * @returns True if the other value is greater than or equal to this value, false otherwise
    */
-  public gte(other: BigUnitish): boolean {
-    if (other instanceof BigUnit) {
-      const highestPrecision = Math.max(this.precision, other.precision);
-      return (
-        this.asPrecision(highestPrecision).value >=
-        other.asPrecision(highestPrecision).value
-      );
-    }
-    return this.value >= BigUnit.from(other, this.precision).value;
+  public gte(other: BigUnitish, otherPrecision?: number): boolean {
+    const otherUnit = this.makeOther(other, otherPrecision); 
+    const [thisUnitAtHighestPrecision, otherUnitAtHighestPrecision] = BigUnit.asHighestPrecision(this, otherUnit);
+ 
+    return thisUnitAtHighestPrecision.value >= otherUnitAtHighestPrecision.value;
   }
 
   /**
@@ -275,15 +272,11 @@ export class BigUnit {
    * @param other
    * @returns True if the other value is less than or equal to this value, false otherwise
    */
-  public lte(other: BigUnitish): boolean {
-    if (other instanceof BigUnit) {
-      const highestPrecision = Math.max(this.precision, other.precision);
-      return (
-        this.asPrecision(highestPrecision).value <=
-        other.asPrecision(highestPrecision).value
-      );
-    }
-    return this.value <= BigUnit.from(other, this.precision).value;
+  public lte(other: BigUnitish, otherPrecision?: number): boolean {
+    const otherUnit = this.makeOther(other, otherPrecision); 
+    const [thisUnitAtHighestPrecision, otherUnitAtHighestPrecision] = BigUnit.asHighestPrecision(this, otherUnit);
+ 
+    return thisUnitAtHighestPrecision.value <= otherUnitAtHighestPrecision.value;
   }
 
   /**
@@ -308,6 +301,15 @@ export class BigUnit {
    */
   public isNegative(): boolean {
     return this.value < 0n;
+  }
+
+  /**
+   * @description Output a zero value BigUnit
+   * @param precision The precision of the zero value, default to 0
+   * @returns 
+   */
+  public static zero(precision?: number): BigUnit {
+    return BigUnit.from(0, precision ?? 0);
   }
 
   /**

--- a/test/bigunit.operations.test.ts
+++ b/test/bigunit.operations.test.ts
@@ -1,5 +1,5 @@
 import { BigUnit } from "../src/bigunit";
-import { DivisionByZeroError } from "../src/errors";
+import { DivisionByZeroError, MissingPrecisionError } from "../src/errors";
 import { bigintCloseTo } from "../src/utils";
 
 describe("BigUnit Class Methods", () => {
@@ -9,10 +9,10 @@ describe("BigUnit Class Methods", () => {
   const unitValue2 = 500n;
   const unitValue3 = -500n;
   const unitValue4 = -1000n;
-  const unit1 = new BigUnit(unitValue1, precision);
-  const unit2 = new BigUnit(unitValue2, precision);
-  const unit3 = new BigUnit(unitValue3, precision);
-  const unit4 = new BigUnit(unitValue4, precision);
+  const unit1 = new BigUnit(unitValue1, precision); //10.00
+  const unit2 = new BigUnit(unitValue2, precision); //5.00
+  const unit3 = new BigUnit(unitValue3, precision); //-5.00
+  const unit4 = new BigUnit(unitValue4, precision); //-10.00
 
   const unit5 = new BigUnit(unitValue1, highPrecision);
   const unit6 = new BigUnit(unitValue2, highPrecision);
@@ -33,6 +33,16 @@ describe("BigUnit Class Methods", () => {
       const result2 = unit7.add(unit6);
       expect(result2.value).toBe(50000000500n);
       expect(result2.precision).toBe(highPrecision);
+    });
+
+    test("require precision if other unit is a bigint", () => {
+      // Expect to throw a MissingPrecisionError
+      expect(() => {
+        unit1.add(1000n);
+      }).toThrow(MissingPrecisionError)
+
+      const result = unit1.add(new BigUnit(1000n, precision));
+      expect(result.value).toBe(unitValue1 + 1000n);
     });
 
     test("should handle negative values and zero correctly", () => {
@@ -67,6 +77,16 @@ describe("BigUnit Class Methods", () => {
       const result2 = unit7.sub(unit6);
       expect(result2.value).toBe(49999999500n);
       expect(result2.precision).toBe(highPrecision);
+    });
+
+    test("require precision if other unit is a bigint", () => {
+      // Expect to throw a MissingPrecisionError
+      expect(() => {
+        unit1.sub(1000n);
+      }).toThrow(MissingPrecisionError)
+
+      const result = unit1.sub(new BigUnit(1000n, precision));
+      expect(result.value).toBe(unitValue1 - 1000n);
     });
 
     it("should handle negative values and zero correctly", () => {
@@ -148,6 +168,16 @@ describe("BigUnit Class Methods", () => {
         expect(result.precision).toBe(expectedPrecision);
       },
     );
+
+    test("require precision if other unit is a bigint", () => {
+      // Expect to throw a MissingPrecisionError
+      expect(() => {
+        unit1.mul(1000n);
+      }).toThrow(MissingPrecisionError)
+
+      const result = unit1.mul(new BigUnit(1000n, precision));
+      expect(result.toNumber()).toBe(100);
+    });
   });
 
   describe("div method", () => {
@@ -217,6 +247,16 @@ describe("BigUnit Class Methods", () => {
         expect(result.toNumber()).toBe(expectedNumberValue);
         expect(result.precision).toBe(expectedPrecision);
       });
+    });
+    test("require precision if other unit is a bigint", () => {
+      // Expect to throw a MissingPrecisionError
+      expect(() => {
+        unit1.div(200n);
+      }).toThrow(MissingPrecisionError)
+
+      // 10 / 2 = 5
+      const result = unit1.div(new BigUnit(200n, precision));
+      expect(result.toNumber()).toBe(5);
     });
   });
 


### PR DESCRIPTION
Require a precision to be passed when operating on a `bigint`. This is to prevent confusion caused by the precision changing if bigunits are chained together with operator methods. Previously, `BigUnit` would infer the precision based on the precision of the bigunit which is being operated upon.