### PR TITLE
TCIA-1018 Precision overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigunit",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "main": "dist/bigunit.js",
   "license": "MIT",
   "author": "Barry Earsman",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigunit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "dist/bigunit.js",
   "license": "MIT",
   "author": "Barry Earsman",

--- a/src/bigunit.ts
+++ b/src/bigunit.ts
@@ -50,7 +50,7 @@ export class BigUnit {
     }
     const otherUnit =
       other instanceof BigUnit
-        ? other
+        ? other.asPrecision(otherPrecision ?? other.precision)
         : BigUnit.from(other, otherPrecision ?? this.precision);
     return otherUnit;
   }
@@ -122,9 +122,9 @@ export class BigUnit {
    * @param other
    * @returns new BigUnit with the result value in the highest precision
    */
-  public div(other: BigUnitish): BigUnit {
+  public div(other: BigUnitish, otherPrecision?: number): BigUnit {
     // Ensure the other value is a BigUnit
-    const otherUnit = this.makeOther(other);
+    const otherUnit = this.makeOther(other, otherPrecision);
 
     // Determine the highest precision of the two units and convert both units to the highest precision
     const [thisUnitAtHighestPrecision, otherUnitAtHighestPrecision] =
@@ -147,9 +147,9 @@ export class BigUnit {
    * @param other
    * @returns new BigUnit with the result value in the highest precision
    */
-  public mod(other: BigUnitish): BigUnit {
+  public mod(other: BigUnitish, otherPrecision?: number): BigUnit {
     // Ensure the other value is a BigUnit
-    const otherUnit = this.makeOther(other);
+    const otherUnit = this.makeOther(other, otherPrecision);
 
     // Determine the highest precision of the two units and convert both units to the highest precision
     const [thisUnitAtHighestPrecision, otherUnitAtHighestPrecision] =
@@ -225,8 +225,16 @@ export class BigUnit {
    * @param percent
    * @returns new BigUnit with the result value in the same precision
    */
-  public percentBackout(percent: number): BigUnit {
-    return this.div(BigUnit.from(1).percent(percent));
+  public percentBackout(percent: number, otherPrecision?: number): BigUnit {
+    //return this.div(BigUnit.from(1, this.precision).percent(percent), otherPrecision);
+    // Break the above into distinct steps for better understanding
+    const percentUnit = BigUnit.from(percent, this.precision);
+    const oneUnit = BigUnit.from(1, this.precision);
+    const percentValue = this.mul(percentUnit);
+    return this.div(
+      oneUnit.add(percentValue, otherPrecision ?? this.precision),
+      otherPrecision ?? this.precision,
+    );
   }
 
   /**

--- a/src/bigunit.ts
+++ b/src/bigunit.ts
@@ -226,14 +226,14 @@ export class BigUnit {
    * @returns new BigUnit with the result value in the same precision
    */
   public percentBackout(percent: number, otherPrecision?: number): BigUnit {
-    //return this.div(BigUnit.from(1, this.precision).percent(percent), otherPrecision);
-    // Break the above into distinct steps for better understanding
-    const percentUnit = BigUnit.from(percent, this.precision);
-    const oneUnit = BigUnit.from(1, this.precision);
-    const percentValue = this.mul(percentUnit);
+    // Calculate 1 + percent/100 to adjust the base by the given percent
+    const precision = otherPrecision ?? this.precision;
+    const adjustmentFactor = BigUnit.from(1 + percent / 100, precision);
+  
+    // Divide the current value by the adjustment factor to reverse the percentage
     return this.div(
-      oneUnit.add(percentValue, otherPrecision ?? this.precision),
-      otherPrecision ?? this.precision,
+      adjustmentFactor,
+      precision
     );
   }
 

--- a/test/bigunit.comparisons.test.ts
+++ b/test/bigunit.comparisons.test.ts
@@ -61,42 +61,6 @@ describe("BigUnit Class Comparison Methods", () => {
       expect(bigUnit.lt(higherValueUnit.toNumber())).toBe(true);
       expect(bigUnit.lt(higherValueUnit.toString())).toBe(true);
     });
-
-    test("comparisons with differing precision", () => {
-      const unit1 = BigUnit.from("9.1", 1);
-      const unit2 = BigUnit.from("9.12", 2);
-      const unit3 = BigUnit.from("9.12", 3);
-
-      expect(unit1.gt(unit2)).toBe(false);
-      expect(unit2.gt(unit1)).toBe(true);
-      expect(unit2.gt(unit3)).toBe(false);
-      expect(unit3.gt(unit2)).toBe(false);
-      expect(unit1.gt(unit1)).toBe(false);
-
-      expect(unit1.lt(unit2)).toBe(true);
-      expect(unit2.lt(unit1)).toBe(false);
-      expect(unit2.lt(unit3)).toBe(false);
-      expect(unit3.lt(unit2)).toBe(false);
-      expect(unit1.lt(unit1)).toBe(false);
-
-      expect(unit1.gte(unit2)).toBe(false);
-      expect(unit2.gte(unit1)).toBe(true);
-      expect(unit2.gte(unit3)).toBe(true);
-      expect(unit3.gte(unit2)).toBe(true);
-      expect(unit1.gte(unit1)).toBe(true);
-
-      expect(unit1.lte(unit2)).toBe(true);
-      expect(unit2.lte(unit1)).toBe(false);
-      expect(unit2.lte(unit3)).toBe(true);
-      expect(unit3.lte(unit2)).toBe(true);
-      expect(unit1.lte(unit1)).toBe(true);
-
-      expect(unit1.eq(unit2)).toBe(false);
-      expect(unit2.eq(unit1)).toBe(false);
-      expect(unit2.eq(unit3)).toBe(true);
-      expect(unit3.eq(unit2)).toBe(true);
-      expect(unit1.eq(unit1)).toBe(true);
-    });
   });
 
   describe("gte (greater than or equal to) method", () => {
@@ -137,5 +101,56 @@ describe("BigUnit Class Comparison Methods", () => {
       expect(bigUnit.lte(higherValueUnit.toNumber())).toBe(true);
       expect(bigUnit.lte(higherValueUnit.toString())).toBe(true);
     });
+  });
+
+  test("comparisons with differing precision", () => {
+    const unit1 = BigUnit.from("9.1", 1);
+    const unit2 = BigUnit.from("9.12", 2);
+    const unit3 = BigUnit.from("9.12", 3);
+
+    expect(unit1.gt(unit2)).toBe(false);
+    expect(unit2.gt(unit1)).toBe(true);
+    expect(unit2.gt(unit3)).toBe(false);
+    expect(unit3.gt(unit2)).toBe(false);
+    expect(unit1.gt(unit1)).toBe(false);
+
+    expect(unit1.lt(unit2)).toBe(true);
+    expect(unit2.lt(unit1)).toBe(false);
+    expect(unit2.lt(unit3)).toBe(false);
+    expect(unit3.lt(unit2)).toBe(false);
+    expect(unit1.lt(unit1)).toBe(false);
+
+    expect(unit1.gte(unit2)).toBe(false);
+    expect(unit2.gte(unit1)).toBe(true);
+    expect(unit2.gte(unit3)).toBe(true);
+    expect(unit3.gte(unit2)).toBe(true);
+    expect(unit1.gte(unit1)).toBe(true);
+
+    expect(unit1.lte(unit2)).toBe(true);
+    expect(unit2.lte(unit1)).toBe(false);
+    expect(unit2.lte(unit3)).toBe(true);
+    expect(unit3.lte(unit2)).toBe(true);
+    expect(unit1.lte(unit1)).toBe(true);
+
+    expect(unit1.eq(unit2)).toBe(false);
+    expect(unit2.eq(unit1)).toBe(false);
+    expect(unit2.eq(unit3)).toBe(true);
+    expect(unit3.eq(unit2)).toBe(true);
+    expect(unit1.eq(unit1)).toBe(true);
+  });
+
+  test("comparisons with differing precision, using a precision override", () => {
+    // A normal comparison would show one being greater than the other,
+    // but with a precision override, they are equal.
+    const unit1 = BigUnit.from("9.123", 3);
+    const unit2 = BigUnit.from("9.12", 2);
+
+    // Without override
+    expect(unit2.eq(unit1)).toBe(false);
+    expect(unit2.lt(unit1)).toBe(true);
+
+    // With override
+    expect(unit2.eq(unit1, 2)).toBe(true);
+    expect(unit2.lt(unit1, 2)).toBe(false);
   });
 });

--- a/test/bigunit.operations.test.ts
+++ b/test/bigunit.operations.test.ts
@@ -35,6 +35,13 @@ describe("BigUnit Class Methods", () => {
       expect(result2.precision).toBe(highPrecision);
     });
 
+    test("should add two BigUnit instances, respecting a precision override", () => {
+      const unitA = BigUnit.fromNumber(1000, 10);
+      const unitB = BigUnit.fromNumber(1000.001, 10);
+      const result = unitA.add(unitB, 2);
+      expect(result.toNumber()).toBe(2000.0);
+    });
+
     test("require precision if other unit is a bigint", () => {
       // Expect to throw a MissingPrecisionError
       expect(() => {
@@ -77,6 +84,13 @@ describe("BigUnit Class Methods", () => {
       const result2 = unit7.sub(unit6);
       expect(result2.value).toBe(49999999500n);
       expect(result2.precision).toBe(highPrecision);
+    });
+
+    test("should subtract two BigUnit instances, respecting a precision override", () => {
+      const unitA = BigUnit.fromNumber(1000, 10);
+      const unitB = BigUnit.fromNumber(100.001, 10);
+      const result = unitA.sub(unitB, 2);
+      expect(result.toNumber()).toBe(900.0);
     });
 
     test("require precision if other unit is a bigint", () => {
@@ -169,6 +183,13 @@ describe("BigUnit Class Methods", () => {
       },
     );
 
+    test("should multiply two BigUnit instances, respecting a precision override", () => {
+      const unitA = BigUnit.fromNumber(1000, 10);
+      const unitB = BigUnit.fromNumber(1.001, 10);
+      const result = unitA.mul(unitB, 2);
+      expect(result.toNumber()).toBe(1000.0);
+    });
+
     test("require precision if other unit is a bigint", () => {
       // Expect to throw a MissingPrecisionError
       expect(() => {
@@ -248,6 +269,14 @@ describe("BigUnit Class Methods", () => {
         expect(result.precision).toBe(expectedPrecision);
       });
     });
+
+    test("should divide two BigUnit instances, respecting a precision override", () => {
+      const unitA = BigUnit.fromNumber(1000, 10);
+      const unitB = BigUnit.fromNumber(2.001, 10);
+      const result = unitA.div(unitB, 2);
+      expect(result.toNumber()).toBe(500.0);
+    });
+
     test("require precision if other unit is a bigint", () => {
       // Expect to throw a MissingPrecisionError
       expect(() => {
@@ -404,6 +433,10 @@ describe("BigUnit Class Methods - percent and fraction", () => {
 
       expect(result.value).toBe(expectedValue);
     });
+  });
+
+  describe("percentBackout method", () => {
+    test("should calculate the percent backout correctly with a valid percentage", () => {});
   });
 
   describe("BigUnit Class Methods - min and max", () => {

--- a/test/bigunit.operations.test.ts
+++ b/test/bigunit.operations.test.ts
@@ -436,7 +436,23 @@ describe("BigUnit Class Methods - percent and fraction", () => {
   });
 
   describe("percentBackout method", () => {
-    test("should calculate the percent backout correctly with a valid percentage", () => {});
+    test("should calculate the percent backout correctly with a valid percentage", () => {
+      const amountWithGst = BigUnit.fromNumber(110.0, 4); // Make sure the precision matches throughout
+      const result = amountWithGst.percentBackout(10.0);
+      expect(result.toNumber()).toBeCloseTo(100.0); // Use toBeCloseTo for floating point precision issues
+    });
+
+    test("should handle zero percent correctly", () => {
+      const amountWithGst = BigUnit.fromNumber(110.0, 4);
+      const result = amountWithGst.percentBackout(0.0);
+      expect(result.toNumber()).toBeCloseTo(110.0);
+    });
+
+    test("should handle precision override correctly", () => {
+      const amountWithGst = BigUnit.fromNumber(110.0011, 4);
+      const result = amountWithGst.percentBackout(10.0, 2);
+      expect(result.toNumber()).toBeCloseTo(100.0);
+    });
   });
 
   describe("BigUnit Class Methods - min and max", () => {


### PR DESCRIPTION
If a precision is passed, it will override the precision used to make the "other" unit, which would otherwise default to the `this` instance.

Fixed `percentBackout()`

Added extra tests.